### PR TITLE
Course Page fixes

### DIFF
--- a/client/src/app/components/LectureList/LectureList.js
+++ b/client/src/app/components/LectureList/LectureList.js
@@ -7,22 +7,23 @@ class LectureList extends React.Component {
     const courseId = this.props.params.courseId;
     return (
       <div>
-        {this.props.course.lectures.map((lecture, i) => {
+        {Object.keys(this.props.course.lectures).map((lecture, i) => {
+          console.log(lecture);
           return (
             <div className="lecture-row" key={i}>
               <LectureItem
-                key={courseId + lecture.lectureId}
+                key={courseId + lecture}
                 courseId={courseId}
-                lectureId={lecture.lectureId}
-                title={lecture.title}
-                date={lecture.date}
+                lectureId={lecture}
+                title={lecture}
+                date={this.props.course.lectures[lecture].timestamp}
                 compact={true}
                 justThumb={true}
               />
             <div className="lecture-info">
-                <h5><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>{lecture.title}</Link></h5>
-                <h6><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>{(new Date(lecture.date)).toDateString()}</Link></h6>
-                <h6><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>TIME</Link></h6>
+                <h5><Link to={`/courses/${courseId}/lecture/${lecture}`}>{lecture}</Link></h5>
+                <h6><Link to={`/courses/${courseId}/lecture/${lecture}`}>{(new Date(this.props.course.lectures[lecture].timestamp)).toDateString()}</Link></h6>
+                <h6><Link to={`/courses/${courseId}/lecture/${lecture}`}>{this.props.course.lectures[lecture].duration}</Link></h6>
               </div>
             </div>
           );

--- a/client/src/app/components/LectureList/LectureList.js
+++ b/client/src/app/components/LectureList/LectureList.js
@@ -1,0 +1,40 @@
+import React from "react";
+import {Link} from "react-router";
+import LectureItem from "components/LectureItem/LectureItem";
+
+class LectureList extends React.Component {
+  render() {
+    const courseId = this.props.params.courseId;
+    return (
+      <div>
+        {this.props.course.lectures.map((lecture, i) => {
+          return (
+            <div className="lecture-row" key={i}>
+              <LectureItem
+                key={courseId + lecture.lectureId}
+                courseId={courseId}
+                lectureId={lecture.lectureId}
+                title={lecture.title}
+                date={lecture.date}
+                compact={true}
+                justThumb={true}
+              />
+            <div className="lecture-info">
+                <h5><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>{lecture.title}</Link></h5>
+                <h6><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>{(new Date(lecture.date)).toDateString()}</Link></h6>
+                <h6><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>TIME</Link></h6>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+LectureList.propTypes = {
+  course: React.PropTypes.object.isRequired,
+  params: React.PropTypes.object
+};
+
+export default LectureList;

--- a/client/src/app/components/LectureList/lecturelist.scss
+++ b/client/src/app/components/LectureList/lecturelist.scss
@@ -1,0 +1,47 @@
+@import "mixins";
+@import "bourbon";
+@import "neat";
+
+.course {
+  @include globalPadding();
+  @include outer-container(90%);
+
+  .lecture-row{
+    @include row();
+  }
+  .lecture-info{
+    margin-left: 245px;
+    padding-left: 50px;
+    padding-top: 28px;
+
+    h5{
+      font-size: 28px;
+      margin: 0px;
+      font-weight: lighter;
+      //text-align: center;
+    }
+    h6{
+      font-weight: lighter;
+      font-size: 16px;
+      margin: 0px;
+      //text-align: center;
+    }
+  }
+  .lecture-info:hover {
+    font-weight: lighter;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  h1{
+      margin-top: 0px;
+      margin-bottom: 25px;
+  }
+  a {
+    text-decoration: none;
+    color: black;
+  }
+  a:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/client/src/app/pages/App/Course/Course.js
+++ b/client/src/app/pages/App/Course/Course.js
@@ -8,7 +8,7 @@ class Course extends React.Component {
   render() {
     return (
       <div className="course">
-        <Link to="/courses">My Courses</Link> / <Link to={`/courses/${this.props.course.id}`}>{this.props.course.title.split(":")[0]}</Link>
+        <Link to="/courses">My Courses</Link> / {this.props.course.title.split(":")[0]} /
         <h1>{this.props.course.title}</h1>
         <LectureList course={this.props.course} params={this.props.params}/>
       </div>

--- a/client/src/app/pages/App/Course/Course.js
+++ b/client/src/app/pages/App/Course/Course.js
@@ -1,62 +1,30 @@
 import React from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router";
-import {getCoursesAction} from "./../../../libs/actions";
-import LectureItem from "components/LectureItem/LectureItem";
+import LectureList from "components/LectureList/LectureList";
 
 class Course extends React.Component {
-  componentWillMount() {
-    this.props.getCourses();
-  }
+
   render() {
-    const courseId = this.props.params.courseId;
     return (
       <div className="course">
         <Link to="/courses">My Courses</Link> / <Link to={`/courses/${this.props.course.id}`}>{this.props.course.title.split(":")[0]}</Link>
         <h1>{this.props.course.title}</h1>
-
-        {this.props.lectures.map((lecture, i) => {
-          return (
-            <div className="lecture-row" key={i}>
-              <LectureItem
-                key={courseId + lecture.lectureId}
-                courseId={courseId}
-                lectureId={lecture.lectureId}
-                title={lecture.title}
-                date={lecture.date}
-                compact={true}
-                justThumb={true}
-              />
-            <div className="lecture-info">
-                <h5><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>{lecture.title}</Link></h5>
-                <h6><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>{(new Date(lecture.date)).toDateString()}</Link></h6>
-                <h6><Link to={`/courses/${courseId}/lecture/${lecture.lectureId}`}>TIME</Link></h6>
-              </div>
-            </div>
-          );
-        })}
+        <LectureList course={this.props.course} params={this.props.params}/>
       </div>
     );
   }
 }
 
 Course.propTypes = {
-  params: React.PropTypes.object,
-  lectures: React.PropTypes.array.isRequired,
   course: React.PropTypes.object.isRequired,
-  getCourses: React.PropTypes.func.isRequired
+  params: React.PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => {
-  let course = state.courses[ownProps.params.courseId];
-  let lectures = state.lectures.filter(lecture => course.lectures.indexOf(lecture.lectureId) >= 0);
-  return {course, lectures};
-};
-
-const mapDispatchToProps = dispatch => {
   return {
-    getCourses: () => dispatch(getCoursesAction())
+    course: state.courses[ownProps.params.courseId]
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Course);
+export default connect(mapStateToProps)(Course);

--- a/client/src/app/pages/App/Courses/Courses.js
+++ b/client/src/app/pages/App/Courses/Courses.js
@@ -7,6 +7,7 @@ class Courses extends React.Component {
   render() {
     return (
       <div className="courses">
+        My Courses /
         <h1>My Courses</h1>
         <CourseList courses={this.props.courses}/>
       </div>


### PR DESCRIPTION
Fixed the courses page being with the new data model.

Also noticed a problem when refreshing the page, since the get is tied to the top level app, it does not seem to understand what to do when there is a get from a particular page (in this case, /course/courseID. Need to go back to the index and then return to route. Will discuss on Friday.

Also followed Doug's advice and put the My Courses / text on the main courses page.